### PR TITLE
Adding workflow and resolving markdown linting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,59 @@
+name: PR Checks
+
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+
+      - name: Set up Go
+        uses: actions/setup-go@v5.4.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Get dependencies
+        run: go mod download
+
+      - name: Build
+        run: go build -v .
+
+      - name: Run linting
+        uses: golangci/golangci-lint-action@v7.0.0
+        with:
+          version: latest
+          args: --timeout=5m
+
+  markdown:
+    name: Lint Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.4.0
+        with:
+          node-version: '16'
+
+      - name: Install markdownlint
+        run: npm install -g markdownlint-cli
+
+      - name: Lint Markdown files
+        run: |
+          markdownlint '**/*.md' \
+            --ignore node_modules \
+            --ignore '**/output/**' \
+            --config .markdownlint.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,16 @@ on:
       - "v*"
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: cli/gh-extension-precompile@v2
+      - uses: actions/checkout@v4.2.2
+
+      - uses: cli/gh-extension-precompile@v2.0.0
         with:
-          go_version: "1.23"
+          generate_attestations: true
+          go_version_file: go.mod

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,25 @@
+# Example markdownlint configuration with all properties set to their default value
+
+# Default state for all rules
+default: true
+
+MD013:
+  # Number of characters
+  line_length: 100
+  # Number of characters for headings
+  heading_line_length: 100
+  # Number of characters for code blocks
+  code_block_line_length: 100
+  # Include code blocks
+  code_blocks: false
+  # Include tables
+  tables: false
+  # Include headings
+  headings: true
+  # Strict length checking
+  strict: false
+  # Stern length checking
+  stern: false
+MD033:
+  # Allowed elements
+  allowed_elements: [tr, td, code, th, summary, details, table, b]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
 # gh-seva
 
-A GitHub `gh` [CLI](https://cli.github.com/) extension to list and create Secrets and Variables defined at an Organization level and/or Repository level.
+[![GitHub Release](https://img.shields.io/github/v/release/katiem0/gh-seva?style=flat&logo=github)](https://github.com/katiem0/gh-seva/releases)
+[![PR Checks](https://github.com/katiem0/gh-seva/actions/workflows/main.yml/badge.svg)](https://github.com/katiem0/gh-seva/actions/workflows/main.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Go Report Card](https://goreportcard.com/badge/github.com/katiem0/gh-seva)](https://goreportcard.com/report/github.com/katiem0/gh-seva)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/katiem0/gh-seva)](https://go.dev/)
+
+A GitHub `gh` [CLI](https://cli.github.com/) extension to list and create Secrets and Variables
+defined at an Organization level and/or Repository level.
 
 ## Installation
 
-1. Install the `gh` CLI - see the [installation](https://github.com/cli/cli#installation) instructions.
+1. Install the `gh` CLI - see the [installation](https://github.com/cli/cli#installation)
+   instructions.
 
 2. Install the extension:
+
    ```sh
    gh extension install katiem0/gh-seva
    ```
@@ -15,13 +24,15 @@ For more information: [`gh extension install`](https://cli.github.com/manual/gh_
 
 ## Usage
 
-This extension supports listing and creating secrets and variables between `GitHub.com` and GitHub Enterprise Server, through the use of `--hostname` and `--source-hostname`.
+This extension supports listing and creating secrets and variables between `GitHub.com` and
+GitHub Enterprise Server, through the use of `--hostname` and `--source-hostname`.
 
-If you are listing or creating org level secrets or variables, you'll need to ensure you have logged in with the `admin:org` scope. To do so, run the following command:
+If you are listing or creating org level secrets or variables, you'll need to ensure you
+have logged in with the `admin:org` scope. To do so, run the following command:
+
 ```sh
 gh auth login -s admin:org
 ```
-
 
 ```sh
 $ gh seva -h
@@ -42,7 +53,8 @@ Use "seva [command] --help" for more information about a command.
 
 ### Secrets
 
-The `gh seva secrets` command comprises of two subcommands, `export` and `create`, to access and create Organization level and repository level secrets.
+The `gh seva secrets` command comprises of two subcommands, `export` and `create`, to access
+and create Organization level and repository level secrets.
 
 ```sh
 $ gh seva secrets -h
@@ -63,15 +75,19 @@ Use "seva secrets [command] --help" for more information about a command.
 
 #### Create Secrets
 
-The `gh seva secrets create` command will create secrets from a `csv` file that contains the following information:
+The `gh seva secrets create` command will create secrets from a `csv` file that contains
+the following information:
 
 - `SecretLevel`: If the secret was created at the organization or repository level
 - `SecretType`: If the secret was created for `Actions`, `Dependabot` or `Codespaces`
 - `SecretName`: The name of the secret
--	`SecretValue`: The value of the secret that will be [encrypted using the associated `public key`](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
-- `SecretAccess`: If an organization level secret, the visibility of the secret (i.e. `all`, `private`, or `scoped`)
-- `RepositoryNames`: The name of the repositories that the secret can be accessed from (delimited with `;`)
-- `RepositoryIDs`: The `id` of the repositories that the secret can be accessed from (delimited with `;`)
+- `SecretValue`: The value of the secret that will be [encrypted using the associated `public key`](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+- `SecretAccess`: If an organization level secret, the visibility of the secret
+  (i.e. `all`, `private`, or `scoped`)
+- `RepositoryNames`: The name of the repositories that the secret can be accessed
+  from (delimited with `;`)
+- `RepositoryIDs`: The `id` of the repositories that the secret can be accessed
+  from (delimited with `;`)
 
 This extension supports `GitHub.com` and GHES, through the use of `--hostname` and `--token`.
 
@@ -94,15 +110,21 @@ Global Flags:
 
 #### Export Secrets
 
-The `gh seva secrets export` command exports secrets for the specified `<organization>` or `[repo ..]` list. If `<organization>` is selected, **both organization level and repository level secrets will be exported**. The report will contain secrets produces a `csv` report with the following:
+The `gh seva secrets export` command exports secrets for the specified `<organization>`
+or `[repo ..]` list. If `<organization>` is selected, **both organization level and repository
+level secrets will be exported**. The report will contain secrets produces a `csv` report
+with the following:
 
 - `SecretLevel`: If the secret was created at the organization or repository level
 - `SecretType`: If the secret was created for `Actions`, `Dependabot` or `Codespaces`
 - `SecretName`: The name of the secret
--	`SecretValue`: This field **will be blank**, we cannot export secret values.
-- `SecretAccess`: If an organization level secret, this is the visibility of the secret (i.e. `all`, `private`, or `scoped`)
-- `RepositoryNames`: The name of the repositories that the secret can be accessed from (delimited with `;`)
-- `RepositoryIDs`: The `id` of the repositories that the secret can be accessed from (delimited with `;`)
+- `SecretValue`: This field **will be blank**, we cannot export secret values.
+- `SecretAccess`: If an organization level secret, this is the visibility of the secret
+  (i.e. `all`, `private`, or `scoped`)
+- `RepositoryNames`: The name of the repositories that the secret can be accessed from
+  (delimited with `;`)
+- `RepositoryIDs`: The `id` of the repositories that the secret can be accessed from
+  (delimited with `;`)
 
 This extension supports `GitHub.com` and GHES, through the use of `--hostname` and `--token`.
 
@@ -131,10 +153,12 @@ Organization level Actions variables can be created and exported, relying on the
 - `VariableLevel`: If the variable was created at the organization or repository level
 - `VariableName`: The name of the Actions variable
 - `VariableValue`: The value of the Actions variable
-- `VariableAccess`: If an organization level variable, this is the visibility of the variable (i.e. `all`, `private`, or `scoped`)
-- `RepositoryNames`: The name of the repositories that the variable can be accessed from (delimited with `;`)
-- `RepositoryIDs`: The `id` of the repositories that the variable can be accessed from (delimited with `;`)
-
+- `VariableAccess`: If an organization level variable, this is the visibility of the
+  variable (i.e. `all`, `private`, or `scoped`)
+- `RepositoryNames`: The name of the repositories that the variable can be accessed
+  from (delimited with `;`)
+- `RepositoryIDs`: The `id` of the repositories that the variable can be accessed
+  from (delimited with `;`)
 
 ```sh
 $ gh seva variables -h
@@ -155,9 +179,11 @@ Use "seva variables [command] --help" for more information about a command.
 
 #### Create Variables
 
-Organization level variables can be created from a `csv` file using `--from-file` following the format outlined in [`gh seva variables`](#variables).
+Organization level variables can be created from a `csv` file using `--from-file` following the
+format outlined in [`gh seva variables`](#variables).
 
-* If specifying a Source Organization (`--source-organization`) to retrieve variables and create under a new Org, the `--source-token` is required.
+- If specifying a Source Organization (`--source-organization`) to retrieve variables and
+  create under a new Org, the `--source-token` is required.
 
 ```sh
 $ gh seva variables create -h
@@ -182,14 +208,20 @@ Global Flags:
 
 #### Export Variables
 
-The `gh seva variables export` command exports variables for the specified `<organization>` or `[repo ..]` list. If `<organization>` is selected, **both organization level and repository level variables will be exported**. The report will contain variables produces a `csv` report with the following:
+The `gh seva variables export` command exports variables for the specified `<organization>`
+or `[repo ..]` list. If `<organization>` is selected, **both organization level and repository
+level variables will be exported**. The report will contain variables produces a `csv` report
+with the following:
 
 - `VariableLevel`: If the variable was created at the organization or repository level
 - `VariableName`: The name of the Actions variable
 - `VariableValue`: The value of the Actions variable
-- `VariableAccess`: If an organization level variable, this is the visibility of the variable (i.e. `all`, `private`, or `scoped`)
-- `RepositoryNames`: The name of the repositories that the variable can be accessed from (delimited with `;`)
-- `RepositoryIDs`: The `id` of the repositories that the variable can be accessed from (delimited with `;`)
+- `VariableAccess`: If an organization level variable, this is the visibility of the variable
+  (i.e. `all`, `private`, or `scoped`)
+- `RepositoryNames`: The name of the repositories that the variable can be accessed from
+  (delimited with `;`)
+- `RepositoryIDs`: The `id` of the repositories that the variable can be accessed from
+  (delimited with `;`)
 
 This extension supports `GitHub.com` and GHES, through the use of `--hostname` and `--token`.
 

--- a/cmd/secrets/create/create.go
+++ b/cmd/secrets/create/create.go
@@ -92,6 +92,7 @@ func NewCmdCreate() *cobra.Command {
 	createCmd.PersistentFlags().BoolVarP(&cmdFlags.debug, "debug", "d", false, "To debug logging")
 	if err := createCmd.MarkFlagRequired("from-file"); err != nil {
 		zap.S().Errorf("Error marking from-file flag as required: %v", err)
+		return nil
 	}
 
 	return &createCmd
@@ -106,8 +107,11 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g *utils.APIGetter) error {
 		if err != nil {
 			zap.S().Errorf("Error arose opening secret csv file")
 		}
-		// remember to close the file at the end of the program
-		defer f.Close()
+		defer func() {
+			if err := f.Close(); err != nil {
+				zap.S().Errorf("Error closing file: %v", err)
+			}
+		}()
 		// read csv values using csv.Reader
 		csvReader := csv.NewReader(f)
 		secretData, err = csvReader.ReadAll()
@@ -121,9 +125,11 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g *utils.APIGetter) error {
 	}
 	zap.S().Debugf("Determining secrets to create")
 	for _, importSecret := range importSecretList {
-		if importSecret.Level == "Organization" {
+		switch importSecret.Level {
+		case "Organization":
 			zap.S().Debugf("Gathering Organization level secret %s", importSecret.Name)
-			if importSecret.Type == "Actions" {
+			switch importSecret.Type {
+			case "Actions":
 				zap.S().Debugf("Encrypting Organization level Actions secret %s", importSecret.Name)
 				publicKey, err := g.GetOrgActionPublicKey(owner)
 				if err != nil {
@@ -162,7 +168,7 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g *utils.APIGetter) error {
 				if err != nil {
 					zap.S().Errorf("Error arose creating Actions secret %s", importSecret.Name)
 				}
-			} else if importSecret.Type == "Codespaces" {
+			case "Codespaces":
 				zap.S().Debugf("Encrypting Organization level Codespaces secret %s", importSecret.Name)
 				publicKey, err := g.GetOrgCodespacesPublicKey(owner)
 				if err != nil {
@@ -199,7 +205,7 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g *utils.APIGetter) error {
 				if err != nil {
 					zap.S().Errorf("Error arose creating Organization Codespaces secret %s", importSecret.Name)
 				}
-			} else if importSecret.Type == "Dependabot" {
+			case "Dependabot":
 				zap.S().Debugf("Encrypting Organization level Dependabot secret %s", importSecret.Name)
 				publicKey, err := g.GetOrgDependabotPublicKey(owner)
 				if err != nil {
@@ -239,13 +245,14 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g *utils.APIGetter) error {
 					zap.S().Errorf("Error arose creating Organization Dependabot secret %s", importSecret.Name)
 				}
 
-			} else {
+			default:
 				zap.S().Errorf("Error arose reading secret from csv file")
 			}
-		} else if importSecret.Level == "Repository" {
+		case "Repository":
 			repoName := importSecret.RepositoryNames[0]
 			zap.S().Debugf("Gathering Repository level secret %s", importSecret.Name)
-			if importSecret.Type == "Actions" {
+			switch importSecret.Type {
+			case "Actions":
 				zap.S().Debugf("Encrypting Repository %s level Actions secret %s", repoName, importSecret.Name)
 				publicKey, err := g.GetRepoActionPublicKey(owner, repoName)
 				if err != nil {
@@ -275,7 +282,7 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g *utils.APIGetter) error {
 				if err != nil {
 					zap.S().Errorf("Error arose creating Repository Actions secret %s", importSecret.Name)
 				}
-			} else if importSecret.Type == "Codespaces" {
+			case "Codespaces":
 				zap.S().Debugf("Encrypting Repository level Codespaces secret %s", importSecret.Name)
 				publicKey, err := g.GetRepoCodespacesPublicKey(owner, repoName)
 				if err != nil {
@@ -304,7 +311,7 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g *utils.APIGetter) error {
 				if err != nil {
 					zap.S().Errorf("Error arose creating Repository Codespaces secret %s", importSecret.Name)
 				}
-			} else if importSecret.Type == "Dependabot" {
+			case "Dependabot":
 				zap.S().Debugf("Encrypting Repository level Dependabot secret %s", importSecret.Name)
 				publicKey, err := g.GetRepoDependabotPublicKey(owner, repoName)
 				if err != nil {
@@ -333,11 +340,10 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g *utils.APIGetter) error {
 				if err != nil {
 					zap.S().Errorf("Error arose creating Repository Dependabot secret %s", importSecret.Name)
 				}
-
-			} else {
+			default:
 				zap.S().Errorf("Error arose reading secret from csv file")
 			}
-		} else {
+		default:
 			zap.S().Errorf("Error arose reading in where to create secret %s, check csv file.", importSecret.Name)
 		}
 	}

--- a/cmd/secrets/create/create.go
+++ b/cmd/secrets/create/create.go
@@ -90,7 +90,9 @@ func NewCmdCreate() *cobra.Command {
 	createCmd.PersistentFlags().StringVarP(&cmdFlags.hostname, "hostname", "", "github.com", "GitHub Enterprise Server hostname")
 	createCmd.Flags().StringVarP(&cmdFlags.fileName, "from-file", "f", "", "Path and Name of CSV file to create secrets from (required)")
 	createCmd.PersistentFlags().BoolVarP(&cmdFlags.debug, "debug", "d", false, "To debug logging")
-	createCmd.MarkFlagRequired("from-file")
+	if err := createCmd.MarkFlagRequired("from-file"); err != nil {
+		zap.S().Errorf("Error marking from-file flag as required: %v", err)
+	}
 
 	return &createCmd
 }

--- a/cmd/secrets/export/export.go
+++ b/cmd/secrets/export/export.go
@@ -183,7 +183,8 @@ func runCmdExport(owner string, repos []string, cmdFlags *cmdFlags, g *utils.API
 		}
 
 		for _, orgSecret := range oActionResponseObject.Secrets {
-			if orgSecret.Visibility == "selected" {
+			switch orgSecret.Visibility {
+			case "selected":
 				zap.S().Debugf("Gathering Actions Secrets for %s that are scoped to specific repositories", owner)
 				scoped_repo, err := g.GetScopedOrgActionSecrets(owner, orgSecret.Name)
 				if err != nil {
@@ -213,7 +214,7 @@ func runCmdExport(owner string, repos []string, cmdFlags *cmdFlags, g *utils.API
 				if err != nil {
 					zap.S().Error("Error raised in writing output", zap.Error(err))
 				}
-			} else if orgSecret.Visibility == "private" {
+			case "private":
 				zap.S().Debugf("Gathering Actions Secret %s for %s that is accessible to all internal and private repositories.", orgSecret.Name, owner)
 				var concatRepos []string
 				var concatRepoIds []string
@@ -236,7 +237,7 @@ func runCmdExport(owner string, repos []string, cmdFlags *cmdFlags, g *utils.API
 				if err != nil {
 					zap.S().Error("Error raised in writing output", zap.Error(err))
 				}
-			} else {
+			default:
 				zap.S().Debugf("Gathering public Actions Secret %s for %s", orgSecret.Name, owner)
 				err = csvWriter.Write([]string{
 					"Organization",
@@ -269,7 +270,8 @@ func runCmdExport(owner string, repos []string, cmdFlags *cmdFlags, g *utils.API
 		}
 
 		for _, orgDepSecret := range oDepResponseObject.Secrets {
-			if orgDepSecret.Visibility == "selected" {
+			switch orgDepSecret.Visibility {
+			case "selected":
 				zap.S().Debugf("Gathering Dependabot Secret %s for %s that is scoped to specific repositories", orgDepSecret.Name, owner)
 				scoped_repo, err := g.GetScopedOrgDependabotSecrets(owner, orgDepSecret.Name)
 				if err != nil {
@@ -299,7 +301,7 @@ func runCmdExport(owner string, repos []string, cmdFlags *cmdFlags, g *utils.API
 				if err != nil {
 					zap.S().Error("Error raised in writing output", zap.Error(err))
 				}
-			} else if orgDepSecret.Visibility == "private" {
+			case "private":
 				zap.S().Debugf("Gathering Dependabot Secret %s for %s that is accessible to all internal and private repositories.", orgDepSecret.Name, owner)
 				var concatRepos []string
 				var concatRepoIds []string
@@ -322,7 +324,7 @@ func runCmdExport(owner string, repos []string, cmdFlags *cmdFlags, g *utils.API
 				if err != nil {
 					zap.S().Error("Error raised in writing output", zap.Error(err))
 				}
-			} else {
+			default:
 				zap.S().Debugf("Gathering public Dependabot Secret %s for %s", orgDepSecret.Name, owner)
 				err = csvWriter.Write([]string{
 					"Organization",
@@ -356,7 +358,8 @@ func runCmdExport(owner string, repos []string, cmdFlags *cmdFlags, g *utils.API
 
 		for _, orgCodeSecret := range oCodeResponseObject.Secrets {
 			zap.S().Debugf("Gathering Codespaces Secrets for %s that are scoped to specific repositories", owner)
-			if orgCodeSecret.Visibility == "selected" {
+			switch orgCodeSecret.Visibility {
+			case "selected":
 				scoped_repo, err := g.GetScopedOrgCodespacesSecrets(owner, orgCodeSecret.Name)
 				if err != nil {
 					return err
@@ -385,7 +388,7 @@ func runCmdExport(owner string, repos []string, cmdFlags *cmdFlags, g *utils.API
 				if err != nil {
 					zap.S().Error("Error raised in writing output", zap.Error(err))
 				}
-			} else if orgCodeSecret.Visibility == "private" {
+			case "private":
 				zap.S().Debugf("Gathering Codespaces Secret %s for %s that is accessible to all internal and private repositories.", orgCodeSecret.Name, owner)
 				var concatRepos []string
 				var concatRepoIds []string
@@ -408,7 +411,7 @@ func runCmdExport(owner string, repos []string, cmdFlags *cmdFlags, g *utils.API
 				if err != nil {
 					zap.S().Error("Error raised in writing output", zap.Error(err))
 				}
-			} else {
+			default:
 				zap.S().Debugf("Gathering public Codespaces Secret %s for %s", orgCodeSecret.Name, owner)
 				err = csvWriter.Write([]string{
 					"Organization",

--- a/cmd/variables/export/export.go
+++ b/cmd/variables/export/export.go
@@ -177,7 +177,8 @@ func runCmdExport(owner string, repos []string, cmdFlags *cmdFlags, g *utils.API
 			return err
 		}
 		for _, orgVariable := range oActionResponseObject.Variables {
-			if orgVariable.Visibility == "selected" {
+			switch orgVariable.Visibility {
+			case "selected":
 				zap.S().Debugf("Gathering Actions Variables for %s that are scoped to specific repositories", owner)
 				scoped_repo, err := g.GetScopedOrgActionVariables(owner, orgVariable.Name)
 				if err != nil {
@@ -208,7 +209,7 @@ func runCmdExport(owner string, repos []string, cmdFlags *cmdFlags, g *utils.API
 					zap.S().Error("Error raised in writing output", zap.Error(err))
 					return err
 				}
-			} else if orgVariable.Visibility == "private" {
+			case "private":
 				zap.S().Debugf("Gathering Actions Variables %s for %s that is accessible to all internal and private repositories.", orgVariable.Name, owner)
 				var concatRepos []string
 				var concatRepoIds []string
@@ -231,7 +232,7 @@ func runCmdExport(owner string, repos []string, cmdFlags *cmdFlags, g *utils.API
 					zap.S().Error("Error raised in writing output", zap.Error(err))
 					return err
 				}
-			} else {
+			default:
 				zap.S().Debugf("Gathering public Actions Secret %s for %s", orgVariable.Name, owner)
 				err = csvWriter.Write([]string{
 					"Organization",

--- a/internal/utils/secrets_actions.go
+++ b/internal/utils/secrets_actions.go
@@ -57,7 +57,11 @@ func (g *APIGetter) GetOrgActionPublicKey(owner string) ([]byte, error) {
 	if err != nil {
 		log.Printf("Body read error, %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.S().Errorf("Error closing response body: %v", err)
+		}
+	}()
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("Body read error, %v", err)
@@ -72,7 +76,11 @@ func (g *APIGetter) GetRepoActionPublicKey(owner string, repo string) ([]byte, e
 	if err != nil {
 		log.Printf("Body read error, %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.S().Errorf("Error closing response body: %v", err)
+		}
+	}()
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("Body read error, %v", err)
@@ -87,7 +95,11 @@ func (g *APIGetter) CreateOrgActionSecret(owner string, secret string, data io.R
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.S().Errorf("Error closing response body: %v", err)
+		}
+	}()
 	return err
 }
 
@@ -98,6 +110,10 @@ func (g *APIGetter) CreateRepoActionSecret(owner string, repo string, secret str
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.S().Errorf("Error closing response body: %v", err)
+		}
+	}()
 	return err
 }

--- a/internal/utils/secrets_codespaces.go
+++ b/internal/utils/secrets_codespaces.go
@@ -57,7 +57,11 @@ func (g *APIGetter) GetOrgCodespacesPublicKey(owner string) ([]byte, error) {
 	if err != nil {
 		log.Printf("Body read error, %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.S().Errorf("Error closing response body: %v", err)
+		}
+	}()
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("Body read error, %v", err)
@@ -72,7 +76,11 @@ func (g *APIGetter) GetRepoCodespacesPublicKey(owner string, repo string) ([]byt
 	if err != nil {
 		log.Printf("Body read error, %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.S().Errorf("Error closing response body: %v", err)
+		}
+	}()
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("Body read error, %v", err)
@@ -87,7 +95,11 @@ func (g *APIGetter) CreateOrgCodespacesSecret(owner string, secret string, data 
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.S().Errorf("Error closing response body: %v", err)
+		}
+	}()
 	return err
 }
 
@@ -98,6 +110,10 @@ func (g *APIGetter) CreateRepoCodespacesSecret(owner string, repo string, secret
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.S().Errorf("Error closing response body: %v", err)
+		}
+	}()
 	return err
 }

--- a/internal/utils/secrets_dependabot.go
+++ b/internal/utils/secrets_dependabot.go
@@ -57,7 +57,11 @@ func (g *APIGetter) GetOrgDependabotPublicKey(owner string) ([]byte, error) {
 	if err != nil {
 		log.Printf("Body read error, %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.S().Errorf("Error closing response body: %v", err)
+		}
+	}()
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("Body read error, %v", err)
@@ -72,7 +76,11 @@ func (g *APIGetter) GetRepoDependabotPublicKey(owner string, repo string) ([]byt
 	if err != nil {
 		log.Printf("Body read error, %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.S().Errorf("Error closing response body: %v", err)
+		}
+	}()
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("Body read error, %v", err)
@@ -87,7 +95,11 @@ func (g *APIGetter) CreateOrgDependabotSecret(owner string, secret string, data 
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.S().Errorf("Error closing response body: %v", err)
+		}
+	}()
 	return err
 }
 
@@ -98,6 +110,10 @@ func (g *APIGetter) CreateRepoDependabotSecret(owner string, repo string, secret
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.S().Errorf("Error closing response body: %v", err)
+		}
+	}()
 	return err
 }

--- a/internal/utils/variables_create.go
+++ b/internal/utils/variables_create.go
@@ -35,7 +35,11 @@ func GetSourceOrganizationVariables(owner string, g *sourceAPIGetter) ([]byte, e
 	if err != nil {
 		log.Printf("Body read error, %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.S().Errorf("Error closing response body: %v", err)
+		}
+	}()
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("Body read error, %v", err)
@@ -64,7 +68,11 @@ func (g *APIGetter) CreateOrganizationVariable(owner string, data io.Reader) err
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.S().Errorf("Error closing response body: %v", err)
+		}
+	}()
 	return err
 }
 
@@ -75,7 +83,11 @@ func (g *APIGetter) CreateRepoVariable(owner string, repo string, data io.Reader
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.S().Errorf("Error closing response body: %v", err)
+		}
+	}()
 	return err
 }
 


### PR DESCRIPTION
### CI Workflows
* Added a new GitHub Actions workflow (`.github/workflows/main.yml`) to perform PR checks, including building, testing, linting Go code, and linting Markdown files.
* Updated the release workflow (`.github/workflows/release.yml`) to include permissions for generating attestations and updated actions to their latest versions.

### Configuration Updates
* Introduced a markdown linting configuration file (`.markdownlint.yaml`) with default rules and specific settings for line length, allowed elements, and exclusions.

### Documentation Enhancements
* Updated `README.md` to include badges for release version, build status, license, Go report card, and Go version. Improved formatting for better readability and added instructions for required permissions when working with org-level secrets and variables. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-L25) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L45-R57) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R90) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R127) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L134-R161) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L158-R186) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L185-R224)

### Codebase Improvements
* Improved error handling in `cmd/secrets/create/create.go` by logging errors when marking the `from-file` flag as required.

Closes #13 