### PR TITLE
Workflow fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,13 +38,18 @@ jobs:
       - name: Run tests
         run: |
           set -o pipefail
-          go test ./... -race -coverprofile=coverage.txt -covermode=atomic 2>&1 | tee test_output.log
+          go test ./... -race -coverprofile=coverage_raw.txt -covermode=atomic 2>&1 | tee test_output.log
+          
+          # Remove mock files from coverage report
+          grep -v "mock_getter.go" coverage_raw.txt | \
+          grep -v "mock_restclient.go" | \
+          grep -v "test_helpers.go" > coverage.txt || cp coverage_raw.txt coverage.txt
 
       - name: Calculate coverage percentage
         id: coverage
         run: |
           COVERAGE_PCT=$(go tool cover -func=coverage.txt | grep total | awk '{print $3}')
-          echo "Coverage percentage: $COVERAGE_PCT"
+          echo "Coverage percentage (excluding mocks): $COVERAGE_PCT"
           echo "coverage_percentage=$COVERAGE_PCT" >> $GITHUB_OUTPUT
           
           # Set pass/fail threshold

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5.0.0
 
-      - uses: cli/gh-extension-precompile@v2.0.0
+      - uses: cli/gh-extension-precompile@v2.1.0
         with:
           generate_attestations: true
           go_version_file: go.mod


### PR DESCRIPTION
**Test coverage improvements:**

* The test workflow now filters out mock and test helper files (`mock_getter.go`, `mock_restclient.go`, `test_helpers.go`) from the generated coverage report, ensuring that reported coverage reflects only production code.
* The coverage percentage output has been updated to clarify that mocks are excluded.

**Dependency updates in release workflow:**

* Upgraded `actions/checkout` from version `v4.2.2` to `v5.0.0` in `.github/workflows/release.yml`.
* Upgraded `cli/gh-extension-precompile` from version `v2.0.0` to `v2.1.0` in `.github/workflows/release.yml`.